### PR TITLE
Not to be merged

### DIFF
--- a/conformalInference/R/loco.R
+++ b/conformalInference/R/loco.R
@@ -248,7 +248,7 @@ my.z.test = function(z, alpha, k){
   s = sd(z)
   m = mean(z)
   pval = 1-pnorm(m/s*sqrt(n))
-
+  pval = 2 * min(pval, 1 - pval)
   # Apply Bonferroni correction for k tests
   #pval = min(k*pval, 1)
   #alpha = alpha/k
@@ -265,6 +265,7 @@ my.sign.test = function(z, alpha, k){
   s = sum(z>0)
   pval = 1-pbinom(s-1,n,0.5)
 
+  pval = 2 * min(pval, 1 - pval)
   # Apply Bonferroni correction for k tests
   #pval = min(k*pval, 1)
   #alpha = alpha/k
@@ -284,6 +285,7 @@ my.wilcox.test = function(z, alpha, k){
   #pval = min(k*pval, 1)
   #alpha = alpha/k
   
+  pval = 2 * min(pval, 1 - pval)
   out = wilcox.test(z, conf.int=TRUE, conf.level=1-alpha)
   left = out$conf.int[1]
   right = out$conf.int[2]

--- a/conformalInference/R/loco.R
+++ b/conformalInference/R/loco.R
@@ -250,7 +250,7 @@ my.z.test = function(z, alpha, k){
   pval = 1-pnorm(m/s*sqrt(n))
 
   # Apply Bonferroni correction for k tests
-  pval = min(k*pval,1)
+  pval = k*pval
   alpha = alpha/k
   
   q = qnorm(1-alpha/2)
@@ -266,7 +266,7 @@ my.sign.test = function(z, alpha, k){
   pval = 1-pbinom(s-1,n,0.5)
 
   # Apply Bonferroni correction for k tests
-  pval = min(k*pval,1)
+  pval = k*pval
   alpha = alpha/k
   
   j = n - qbinom(1-alpha/2,n,0.5) # Want P(B <= j) <= alpha/2
@@ -281,7 +281,7 @@ my.wilcox.test = function(z, alpha, k){
   pval = wilcox.test(z, alternative="greater")$p.value
 
   # Apply Bonferroni correction for k tests
-  pval = min(k*pval,1)
+  pval = k*pval
   alpha = alpha/k
   
   out = wilcox.test(z, conf.int=TRUE, conf.level=1-alpha)

--- a/conformalInference/R/loco.R
+++ b/conformalInference/R/loco.R
@@ -250,8 +250,8 @@ my.z.test = function(z, alpha, k){
   pval = 1-pnorm(m/s*sqrt(n))
 
   # Apply Bonferroni correction for k tests
-  pval = k*pval
-  alpha = alpha/k
+  #pval = min(k*pval, 1)
+  #alpha = alpha/k
   
   q = qnorm(1-alpha/2)
   left  = m - q*s/sqrt(n)
@@ -266,8 +266,8 @@ my.sign.test = function(z, alpha, k){
   pval = 1-pbinom(s-1,n,0.5)
 
   # Apply Bonferroni correction for k tests
-  pval = k*pval
-  alpha = alpha/k
+  #pval = min(k*pval, 1)
+  #alpha = alpha/k
   
   j = n - qbinom(1-alpha/2,n,0.5) # Want P(B <= j) <= alpha/2
   zz  = sort(z)
@@ -281,8 +281,8 @@ my.wilcox.test = function(z, alpha, k){
   pval = wilcox.test(z, alternative="greater")$p.value
 
   # Apply Bonferroni correction for k tests
-  pval = k*pval
-  alpha = alpha/k
+  #pval = min(k*pval, 1)
+  #alpha = alpha/k
   
   out = wilcox.test(z, conf.int=TRUE, conf.level=1-alpha)
   left = out$conf.int[1]


### PR DESCRIPTION
Just a few changes to loco.R to return uncorrected two-sided p-values and intervals.

Used to illustrate whether or not LOCO really produces "p-values" here:

https://gist.github.com/jonathan-taylor/6c0a0b9a67b9d0a7024206ef4d901cd1#file-loco_pvalues_unsimultaneous-ipynb
