### PR TITLE
Support for non-equal splitting in split conformal regression

### DIFF
--- a/conformalInference/R/split.R
+++ b/conformalInference/R/split.R
@@ -16,6 +16,8 @@
 #'   predictions.
 #' @param alpha Miscoverage level for the prediction intervals, i.e., intervals
 #'   with coverage 1-alpha are formed. Default for alpha is 0.1.
+#' @param rho Fraction of observation in the training set. Rounding is to the 
+#'   integer below, defaults to 0.5
 #' @param w Weights, in the case of covariate shift. This should be a vector of
 #'   length n+n0, giving the weights (i.e., ratio of test to training feature
 #'   densities), at each of n+n0 the training and test points. Default is NULL,
@@ -76,7 +78,7 @@
 #' @export conformal.pred.split
 
 conformal.pred.split = function(x, y, x0, train.fun, predict.fun, alpha=0.1,
-  w=NULL, mad.train.fun=NULL, mad.predict.fun=NULL, split=NULL, seed=NULL,
+  rho=0.5, w=NULL, mad.train.fun=NULL, mad.predict.fun=NULL, split=NULL, seed=NULL,
   verbose=FALSE) {
 
   # Set up data
@@ -91,6 +93,14 @@ conformal.pred.split = function(x, y, x0, train.fun, predict.fun, alpha=0.1,
   check.args(x=x,y=y,x0=x0,alpha=alpha,train.fun=train.fun,
              predict.fun=predict.fun,mad.train.fun=mad.train.fun,
              mad.predict.fun=mad.predict.fun)
+  
+  # Check rho
+  if (is.null(rho) || length(rho)!= 1 || !is.numeric(rho) || rho<0 || rho>1)
+    stop(paste(deparse(substitute(rho)),"must be a number between 0 and 1")
+  if (rho=0)
+    stop("training set should be non-empty")
+  if (rho=1)
+    stop("test set should be non-empty")
 
   # Check the weights
   if (is.null(w)) w = rep(1,n+n0)
@@ -107,7 +117,7 @@ conformal.pred.split = function(x, y, x0, train.fun, predict.fun, alpha=0.1,
   # Otherwise make a random split
   else {
     if (!is.null(seed)) set.seed(seed)
-    i1 = sample(1:n,floor(n/2))
+    i1 = sample(1:n,floor(n*rho))
   }
   i2 = (1:n)[-i1]
   n1 = length(i1)

--- a/conformalInference/examples/ex.conformal.pred.split.R
+++ b/conformalInference/examples/ex.conformal.pred.split.R
@@ -31,6 +31,7 @@ len.split = colMeans(out.split$up - out.split$lo)
 err.split = colMeans((y0.mat - out.split$pred)^2)
 
 # Compare to parametric intervals from oracle linear regression
+
 lm.orac = lm(y~x[,1:s])
 out.orac = predict(lm.orac,newdata=list(x=x0[,1:s]),
   interval="predict", level=0.9)
@@ -123,6 +124,58 @@ plot(log(length(err.split):1),err.split,type="o",pch=20,
      xlab="log(lambda rank) (i.e., log(1)=0 is smallest)",ylab="Test error",
      main=paste0("Split conformal + lasso (dynamic lambda sequence):",
        "\nTest error"))
+abline(h=err.orac,lty=2,col=2)
+legend("topleft",col=1:2,lty=1:2,
+       legend=c("Split conformal","Oracle"))
+
+
+# Inspect different rho parameter
+
+# Split conformal inference 
+out.split = conformal.pred.split(x, y, x0, alpha=0.1, rho=.7,
+                                 train.fun=funs$train, predict.fun=funs$predict)
+
+y0.mat = matrix(rep(y0,ncol(out.split$lo)),nrow=n0)
+cov.split = colMeans(out.split$lo <= y0.mat & y0.mat <= out.split$up)
+len.split = colMeans(out.split$up - out.split$lo)
+err.split = colMeans((y0.mat - out.split$pred)^2)
+
+# Compare to parametric intervals from oracle linear regression
+lm.orac = lm(y~x[,1:s])
+out.orac = predict(lm.orac,newdata=list(x=x0[,1:s]),
+                   interval="predict", level=0.9)
+
+cov.orac = mean(out.orac[,"lwr"] <= y0 & y0 <= out.orac[,"upr"])
+len.orac = mean(out.orac[,"upr"] - out.orac[,"lwr"])
+err.orac = mean((y0 - out.orac[,"fit"])^2)
+
+# Plot average coverage 
+plot(log(length(cov.split):1),cov.split,type="o",pch=20,ylim=c(0,1),
+     xlab="log(lambda rank) (i.e., log(1)=0 is smallest)",
+     ylab="Avg coverage",
+     main=paste0("Split conformal (rho=.7) + lasso (dynamic lambda sequence):",
+                 "\nAverage coverage"))
+abline(h=cov.orac,lty=2,col=2)
+legend("bottomleft",col=1:2,lty=1:2,
+       legend=c("Split conformal","Oracle"))
+
+# Plot average length
+plot(log(length(len.split):1),len.split,type="o",pch=20,
+     ylim=range(len.split,len.orac),
+     xlab="log(lambda rank) (i.e., log(1)=0 is smallest)",
+     ylab="Avg length",
+     main=paste0("Split conformal (rho=.7) + lasso (dynamic lambda sequence):",
+                 "\nAverage length"))
+abline(h=len.orac,lty=2,col=2)
+legend("topleft",col=1:2,lty=1:2,
+       legend=c("Split conformal","Oracle"))
+
+# Plot test error
+plot(log(length(err.split):1),err.split,type="o",pch=20,
+     ylim=range(err.split,err.orac),
+     xlab="log(lambda rank) (i.e., log(1)=0 is smallest)",ylab="Test error",
+     main=paste0("Split conformal (rho=.7) + lasso (dynamic lambda sequence):",
+                 "\nTest error"))
 abline(h=err.orac,lty=2,col=2)
 legend("topleft",col=1:2,lty=1:2,
        legend=c("Split conformal","Oracle"))


### PR DESCRIPTION
I have added, in the split.conformal.pred function, the rho argument, which allows the user to tweak the splitting ratio of the split.conformal procedure, as well as some example code.

