### PR TITLE
Fix comma typos in DESCRIPTION

### DIFF
--- a/conformalInference/DESCRIPTION
+++ b/conformalInference/DESCRIPTION
@@ -6,11 +6,11 @@ Date: 2019-04-17
 Authors@R: c(
     person(given = "Ryan", family = "Tibshirani", role = c("aut", "cre"),
            email = "ryantibs@cmu.edu"),
-    person(given = "Paolo", family = "Vergottini", role = "aut")
+    person(given = "Paolo", family = "Vergottini", role = "aut"),
     person(given = "Matteo", family = "Fontana", role = "aut",
            email = "matteo.fontana@ec.europa.eu"),
     person(given = "Jacopo", family = "Diquigiovanni", role = "aut"),
-    person(given = "Aldo", family = "Solari", role = "ctb"),
+    person(given = "Aldo", family = "Solari", role = "ctb")
     )
 Depends:
 Suggests:


### PR DESCRIPTION
Misplaced commas in Authors field prevented me from installing {conformalInference} R package. After fixing the commas in my local copy, installation works for me now.